### PR TITLE
Add option to override API base

### DIFF
--- a/Workflow/chatgpt
+++ b/Workflow/chatgpt
@@ -58,7 +58,7 @@ function markdownChat(messages, ignoreLastInterrupted = true) {
   }, "")
 }
 
-function startStream(apiEndpoint, apiKey, apiOrgHeader, model, systemPrompt, contextChat, streamFile, pidStreamFile) {
+function startStream(apiEndpoint, apiBase, apiKey, apiOrgHeader, model, systemPrompt, contextChat, streamFile, pidStreamFile) {
   $.NSFileManager.defaultManager.createFileAtPathContentsAttributes(streamFile, undefined, undefined) // Create empty file
 
   const messages = systemPrompt ?
@@ -70,7 +70,7 @@ function startStream(apiEndpoint, apiKey, apiOrgHeader, model, systemPrompt, con
 
   task.executableURL = $.NSURL.fileURLWithPath("/usr/bin/curl")
   task.arguments = [
-    `${apiEndpoint}/v1/chat/completions`,
+    `${apiEndpoint}${apiBase}`,
     "--speed-limit", "0", "--speed-time", "5", // Abort stalled connection after a few seconds
     "--silent", "--no-buffer",
     "--header", "Content-Type: application/json",
@@ -198,6 +198,7 @@ function run(argv) {
   const apiKey = envVar("openai_api_key")
   const apiOrgHeader = envVar("openai_org_id") ? ["--header", `OpenAI-Organization: ${envVar("openai_org_id")}`] : []
   const apiEndpoint = envVar("chatgpt_api_endpoint") || "https://api.openai.com"
+  const apiBase = envVar("chatgpt_api_base") || "/v1/chat/completions"
   const systemPrompt = envVar("system_prompt")
   const model = envVar("chatgpt_model_override") ? envVar("chatgpt_model_override") : envVar("gpt_model")
   const chatFile = `${envVar("alfred_workflow_data")}/chat.json`
@@ -232,7 +233,7 @@ function run(argv) {
   const contextChat = ongoingChat.slice(-maxContext)
 
   // Make API request, write chat file, and start loop
-  startStream(apiEndpoint, apiKey, apiOrgHeader, model, systemPrompt, contextChat, streamFile, pidStreamFile)
+  startStream(apiEndpoint, apiBase, apiKey, apiOrgHeader, model, systemPrompt, contextChat, streamFile, pidStreamFile)
   appendChat(chatFile, appendQuery)
 
   return JSON.stringify({


### PR DESCRIPTION
I tried using the environment variables to override the API URL for use with the Perplexity API, however, the correct URL to call for Perplexity does not use the v1 prefix:

```
$ curl --silent "https://api.perplexity.ai/chat/completions" --header "Authorization: Bearer $openai_key" --header "Content-Type: application/json" --data '{ "model": "llama-3.1-sonar-small-128k-chat", "messages": [{ "role": "user", "content": "What is the Alfred macOS app in one sentence?" }], "stream": false }' | jq -r '.choices[0].message.content'

The Alfred macOS app is a powerful productivity tool that enhances the macOS experience by providing customizable workflows, hotkeys, and search functionality to streamline tasks and improve efficiency.

```

I added an option to set the part after the api endpoint through another environment variable `chatgpt_api_base` which defaults to the previous value of `/v1/chat/completions`.