### PR TITLE
Handle code blocks nested within Markdown

### DIFF
--- a/Workflow/chatgpt
+++ b/Workflow/chatgpt
@@ -38,10 +38,54 @@ function appendChat(path, message) {
   writeFile(path, chatString)
 }
 
+function escapeMarkdownCodeBlocks(markdownText) {
+  if (!markdownText.includes("```markdown")) return markdownText;
+
+  const codeBlockMarkerRegex = /^\s{0,3}```(\w*)/gm;
+  let match;
+  let openCodeBlocks = [];
+  let markdownBlocks = []
+  while((match = codeBlockMarkerRegex.exec(markdownText)) !== null) {
+    const nextLine = markdownText.slice(match.index + match[0].length + 1).match(/^.*$/m);
+    const nextLineEmptyOrClosing = nextLine === null || nextLine[0].trim() === "" || nextLine[0].trim() === "```"; // Empty line or closing code block
+    const markerIsAnnotated = match[1] != "";
+    if (markerIsAnnotated || !nextLineEmptyOrClosing || openCodeBlocks.length === 0) {
+      // Open a new code block
+      openCodeBlocks.push({type: match[1], index: match.index, matchLength: match[0].length});
+    } else {
+      // Close the code block
+      const closed = openCodeBlocks.pop();
+      if (closed.type === "markdown") {
+        markdownBlocks.push({start: closed.index, startLength: closed.matchLength, end: match.index + match[0].length + 1, endLength: match[0].length});
+      }
+    }
+  }
+  // console.log(JSON.stringify(openCodeBlocks.map(block => `[${block.type}] ${markdownText.slice(block.index, block.index + 30)}`), null, 2));
+  // console.log(JSON.stringify(markdownBlocks.map(block => `${markdownText.slice(block.start, block.start + 30)} ... ${markdownText.slice(block.end - 30, block.end)}`), null, 2));
+
+  function indentText(text) {
+    const lines = text.split("\n")
+    return lines.length === 1 ? lines[0] : lines.slice(0,-1).map(line => ` ${line}`).join("\n") + "\n" + lines[lines.length - 1];
+  }
+
+  for (let i = markdownBlocks.length - 1; i >= 0; i--) {
+    const block = markdownBlocks[i];
+    markdownText = (
+      markdownText.slice(0, block.start)
+      + "```markdown"
+      + indentText(markdownText.slice(block.start + block.startLength, block.end - block.endLength - 1))
+      + "```\n"
+      + markdownText.slice(block.end)
+    );
+  }
+
+  return markdownText;
+}
+
 function markdownChat(messages, ignoreLastInterrupted = true) {
   return messages.reduce((accumulator, current, index, allMessages) => {
     if (current["role"] === "assistant")
-      return `${accumulator}${current["content"]}\n\n`
+      return `${accumulator}${escapeMarkdownCodeBlocks(current["content"])}\n\n`
 
     if (current["role"] === "user") {
       const userMessage = current["content"].split("\n").map(line => `### ${line}`).join("\n") // support multi-line questions (e.g. via External Trigger)
@@ -146,7 +190,7 @@ function readStream(streamFile, chatFile, pidStreamFile) {
 
     // Stop
     return JSON.stringify({
-      response: `${responseText} [Connection Stalled]`,
+      response: `${escapeMarkdownCodeBlocks(responseText)} [Connection Stalled]`,
       footer: "You can ask ChatGPT to continue the answer",
       behaviour: { response: "replacelast", scroll: "end" }
     })
@@ -165,7 +209,7 @@ function readStream(streamFile, chatFile, pidStreamFile) {
   if (finishReason === null) return JSON.stringify({
     rerun: 0.1,
     variables: { streaming_now: true },
-    response: responseText,
+    response: escapeMarkdownCodeBlocks(responseText),
     behaviour: { response: "replacelast", scroll: "end" }
   })
 
@@ -184,7 +228,7 @@ function readStream(streamFile, chatFile, pidStreamFile) {
 
   // Stop
   return JSON.stringify({
-    response: responseText,
+    response: escapeMarkdownCodeBlocks(responseText),
     footer: footerText,
     behaviour: { response: "replacelast", scroll: "end" }
   })


### PR DESCRIPTION
### Frequently Asked Questions
- [x] I have [read the FAQ](https://www.alfredforum.com/topic/21483-chatgpt-dall-e-openai-integrations/#comment-111557) before opening the issue

### Workflow version
v2024.17

### Alfred version
5.5.1 [2273]

### macOS version
Sequoia 15.1 (24B83)

### Debugger output
```
[23:19:34.204] ChatGPT / DALL-E[Text View] Running with argument ''
[23:19:34.260] ChatGPT / DALL-E[Text View] Script with argv '' finished
[23:19:34.265] ChatGPT / DALL-E[Text View] {"response":"> Give me examples of markdown, including nested and multiple code blocks\n\nCertainly! Markdown is a lightweight markup language used to format text. Here are some examples, including nested and multiple code blocks:\n\n### Basic Text Formatting\n```markdown\n# Heading 1\n## Heading 2\n### Heading 3\n\n**Bold Text**\n\n*Italic Text*\n\n[Link to OpenAI](https://www.openai.com)\n\n- Bullet list item 1\n- Bullet list item 2\n\n1. Numbered list item 1\n2. Numbered list item 2\n```\n\n### Code Blocks\n```markdown\nInline code: `print(\"Hello, World!\")`\n\nCode block with syntax highlighting (Python):\n```python\ndef greet(name):\n    return f\"Hello, {name}!\"\n\nprint(greet(\"World\"))\n```\n```\n\n### Nested Code Blocks\nMarkdown doesn't support nested code blocks directly, but you can achieve a similar effect using lists:\n\n```markdown\n1. Step involving code:\n\n    ```python\n    def do_something():\n        pass\n    ```\n\n2. Another step with different code:\n\n    ```bash\n    echo \"Hello from bash\"\n    ```\n```\n\n### Multiple Code Blocks\n```markdown\nHere is a JavaScript example:\n\n```javascript\nfunction sayHi() {\n    console.log(\"Hi!\");\n}\nsayHi();\n```\n\nAnd here is a JSON example:\n\n```json\n{\n    \"name\": \"John\",\n    \"age\": 30,\n    \"isStudent\": false\n}\n```\n```\n\n### Blockquotes\n```markdown\n> This is a blockquote.\n>\n> > Nested blockquote with more information.\n>\n> Concluding remarks.\n```\n\n### Tables\n```markdown\n| Syntax | Description |\n|--------|-------------|\n| Header | Title       |\n| Paragraph | Text     |\n```\n\n### Horizontal Rule\n```markdown\n---\n\nor\n\n***\n```\n\nThese examples cover some of the basic and slightly more complex structures you can create with Markdown.\n\n","behaviour":{"scroll":"end"}}
```

### More details
When another code block is nested within a `markdown` code block, Alfred has trouble formatting the output.

Alfred's [Markdown Syntax](https://www.alfredapp.com/help/kb/markdown-syntax/) doesn't specify how nested code blocks should behave.

This is an excerpt from ChatGPT's response using a prompt similar to "Examples of Markdown":

    ### Multiple Code Blocks
    ```markdown
    Here is a JavaScript example:
    
    ```javascript
    function sayHi() {
        console.log("Hi!");
    }
    sayHi();
    ```
    
    And here is a JSON example:
    
    ```json
    {
        "name": "John",
        "age": 30,
        "isStudent": false
    }
    ```
    ```

 <table>
   <tr>
     <td>
       <h3>Current</h3>
       <img width="720" alt="chatgpt_—_user_workflow_23D53FFB-6495-4BEB-AD89-432D664C3FE5" src="https://github.com/user-attachments/assets/50336cfe-82a3-4eed-97fa-dae6f84cdff9">
     </td>
     <td>
       <h3>Updated</h3>
       <img width="735" alt="Updated behavior" src="https://github.com/user-attachments/assets/f32855d9-245f-4e97-a994-173ab1017a8a">
     </td>
   </tr>
 </table>


