### PR TITLE
If the `finishReason` is not returned, then the streaming will not work.

### DIFF
--- a/Workflow/chatgpt
+++ b/Workflow/chatgpt
@@ -162,7 +162,7 @@ function readStream(streamFile, chatFile, pidStreamFile) {
   const finishReason = chunks.slice(-1)[0]["choices"][0]["finish_reason"]
 
   // If reponse is not finished, continue loop
-  if (finishReason === null) return JSON.stringify({
+  if (finishReason === null || finishReason === undefined) return JSON.stringify({
     rerun: 0.1,
     variables: { streaming_now: true },
     response: responseText,


### PR DESCRIPTION
I was trying to use another LLM. and it always can not streaming well.

So after checked the source code and did some troubleshoting work. I found the reason here.
Because my LLM model does not return a `finishReason`.

It works well after I changed the code here.


There are some response, that I got from the LLM server.

```
data: {"created":1732022963,"id":"de598844107d49db83209a7836362406","model":"xxxx-turbo","version":"202409241030","choices":[{"index":0,"delta":{"role":"assistant","content":"我可"}}],"search_info":{"mindmap":{}},"processes":{},"usage":{"prompt_tokens":1061,"completion_tokens":22,"total_tokens":1083}}

data: {"created":1732022963,"id":"de598844107d49db83209a7836362406","model":"xxxx-turbo","version":"202409241030","choices":[{"index":0,"delta":{"role":"assistant","content":"以帮"}}],"search_info":{"mindmap":{}},"processes":{},"usage":{"prompt_tokens":1061,"completion_tokens":24,"total_tokens":1085}}

data: {"created":1732022963,"id":"de598844107d49db83209a7836362406","model":"xxxx-turbo","version":"202409241030","choices":[{"index":0,"delta":{"role":"assistant","content":"你的"}}],"search_info":{"mindmap":{}},"processes":{},"usage":{"prompt_tokens":1061,"completion_tokens":26,"total_tokens":1087}}

data: {"created":1732022963,"id":"de598844107d49db83209a7836362406","model":"xxxx-turbo","version":"202409241030","choices":[{"index":0,"delta":{"role":"assistant","content":"吗？"}}],"search_info":{"mindmap":{}},"processes":{},"usage":{"prompt_tokens":1061,"completion_tokens":28,"total_tokens":1089}}

data: {"created":1732022963,"id":"de598844107d49db83209a7836362406","model":"xxxxx-turbo","version":"202409241030","choices":[{"index":0,"finish_reason":"stop","delta":{"role":"assistant"}}],"search_info":{"mindmap":{}},"processes":{},"usage":{"prompt_tokens":1061,"completion_tokens":29,"total_tokens":1090}}

data: [DONE]
```