### PR TITLE
Fix image generation endpoint path

### DIFF
--- a/Workflow/dalle
+++ b/Workflow/dalle
@@ -76,9 +76,9 @@ function run(argv) {
   const maxEntries = 10
   const apiKey = envVar("openai_api_key")
   const apiOrgHeader = envVar("openai_org_id") ? ["--header", `OpenAI-Organization: ${envVar("openai_org_id")}`] : []
-  const apiEndpointInit = envVar("dalle_api_endpoint") || "https://api.openai.com/v1/images/completions"
+  const apiEndpointInit = envVar("dalle_api_endpoint") || "https://api.openai.com/v1/images/generations"
   const apiEndpointInitHasPath = apiEndpointInit.replace(/^https?:\/\//, "").includes("/")
-  const apiEndpoint = apiEndpointInitHasPath ? apiEndpointInit : `${apiEndpointInit}/v1/images/completions`
+  const apiEndpoint = apiEndpointInitHasPath ? apiEndpointInit : `${apiEndpointInit}/v1/images/generations`
   const model = envVar("dalle_model")
   const imageNumber = parseInt(envVar("dalle_image_number"))
   const imageStyle = envVar("dalle_style")


### PR DESCRIPTION
The endpoint path for the `dalle` script was modified in [this commit](https://github.com/alfredapp/openai-workflow/commit/aa853990654569b57f22e61b30364f0b8298bae7) and doesn't match the [OpenAI API specifications](https://platform.openai.com/docs/api-reference/images/create). This pull request corrects the path.