### PR TITLE
refactor: change streamString definition position to optimize code ef…

### DIFF
--- a/Workflow/chatgpt
+++ b/Workflow/chatgpt
@@ -86,7 +86,6 @@ function startStream(apiEndpoint, apiKey, apiOrgHeader, model, systemPrompt, con
 
 function readStream(streamFile, chatFile, pidStreamFile, timeoutSeconds) {
   const streamMarker = envVar("stream_marker") === "1"
-  const streamString = $.NSString.stringWithContentsOfFileEncodingError(streamFile, $.NSUTF8StringEncoding, undefined).js
 
   // When starting a stream or continuing from a closed window, add a marker to determine the location of future replacements
   if (streamMarker) return JSON.stringify({
@@ -95,6 +94,8 @@ function readStream(streamFile, chatFile, pidStreamFile, timeoutSeconds) {
     response: "…",
     behaviour: { response: "append" }
   })
+
+  const streamString = $.NSString.stringWithContentsOfFileEncodingError(streamFile, $.NSUTF8StringEncoding, undefined).js
 
   // If response looks like proper JSON, it is probably an error
   if (streamString.startsWith("{")) {


### PR DESCRIPTION
In the original version of the file, `streamString` is used after `streamMarker` is checked. This may cause unnecessary file reading and JSON parsing when `streamMarker` is `true`.
The new version of the file solves this problem, the code runs more efficient.