### PR TITLE
Add DALL-E versioning check to strip new params

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ View Chat History with ⌥↩ in the `chatgpt` keyword. Each result shows the fi
 
 ### DALL\267E
 
-Query DALL\267E via the `dalle` keyword.
+Query DALL-E via the `dalle` keyword.
 
 ![Start DALL-E query](Workflow/images/about/dallekeyword.png)
 

--- a/Workflow/dalle
+++ b/Workflow/dalle
@@ -115,20 +115,28 @@ function run(argv) {
   const task = $.NSTask.alloc.init
   const stdout = $.NSPipe.pipe
 
+  const payload = {
+    model: model,
+    prompt: typedQuery,
+    style: imageStyle,
+    quality: imageQuality,
+    n: imageNumber,
+    size: "1024x1024"
+  }
+
+  // Remove incompatible params for DALL-E 2
+  if(!model.includes("dall-e-2") && imageStyle && imageQuality){
+    payload.style = imageStyle;
+    payload.quality = imageQuality; 
+  }
+
   task.executableURL = $.NSURL.fileURLWithPath("/usr/bin/curl")
   task.arguments = [
     apiEndpoint,
     "--silent",
     "--header", "Content-Type: application/json",
     "--header", `Authorization: Bearer ${apiKey}`,
-    "--data", JSON.stringify({
-      model: model,
-      prompt: typedQuery,
-      style: imageStyle,
-      quality: imageQuality,
-      n: imageNumber,
-      size: "1024x1024"
-    })
+    "--data", JSON.stringify(payload)
   ].concat(apiOrgHeader)
 
   task.standardOutput = stdout


### PR DESCRIPTION
The DALL-E workflow has some optional params (quality and style) which are only compatible with DALL-E 3. The workflow still has DALL-E 2 support and this is currently set as a default, and using this causes API errors as the extra params are rejected by the server.

This PR constructs the API call based on the selected model and does not include the incompatible pramas if DALL-E 2 is selected to avoid this failure.

It also nukes some stray ASCII code in the Readme.