### PR TITLE
Add GPT 5.4 models

### DIFF
--- a/Workflow/info.plist
+++ b/Workflow/info.plist
@@ -2420,6 +2420,18 @@ Query DALL·E via the `dalle` keyword.
 				<key>pairs</key>
 				<array>
 					<array>
+						<string>GPT 5.4 nano</string>
+						<string>gpt-5-nano</string>
+					</array>
+					<array>
+						<string>GPT 5.4 mini</string>
+						<string>gpt-5.4-mini</string>
+					</array>
+					<array>
+						<string>GPT 5.4</string>
+						<string>gpt-5.4</string>
+					</array>
+					<array>
 						<string>GPT 5 nano</string>
 						<string>gpt-5-nano</string>
 					</array>


### PR DESCRIPTION
## Summary
Adds GPT 5.4 models to the tool config map.

Tested Locally. Config only changes.